### PR TITLE
Detect Skyrim in Steam libraries

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3712,6 +3712,7 @@ dependencies = [
  "bevy",
  "converter",
  "crossbeam-channel",
+ "winreg",
 ]
 
 [[package]]
@@ -7031,6 +7032,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "winreg"
+version = "0.55.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb5a765337c50e9ec252c2069be9bf91c7df47afb103b642ba3a53bf8101be97"
+dependencies = [
+ "cfg-if",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/crates/converter/src/esm/exporter.rs
+++ b/crates/converter/src/esm/exporter.rs
@@ -170,8 +170,6 @@ pub fn insert_reference(
     let mut pos = [0.0f32; 3];
     let mut rot = [0.0f32; 3];
     let mut scale = 1.0f32;
-    let mut cell_form_id = 0;
-
     for (tag, data) in subs {
         match from_utf8(tag).unwrap_or("") {
             "DATA" if data.len() >= 4 => {
@@ -184,9 +182,6 @@ pub fn insert_reference(
             }
             "XSCL" if data.len() >= 4 => {
                 scale = f32::from_le_bytes([data[0], data[1], data[2], data[3]]);
-            }
-            "CELL" if data.len() >= 4 => {
-                cell_form_id = u32::from_le_bytes([data[0], data[1], data[2], data[3]]);
             }
             _ => {}
         }

--- a/crates/converter/src/esm/records/achr.rs
+++ b/crates/converter/src/esm/records/achr.rs
@@ -15,7 +15,7 @@ use crate::esm::{
     extractors::SubrecordView,
     records::{
         EsmRecord, RawRecord,
-        record_type::vmad::{VmadSubrecord, parse_vmad},
+        record_type::vmad::VmadSubrecord,
     },
 };
 

--- a/crates/converter/src/esm/records/record_type/vmad.rs
+++ b/crates/converter/src/esm/records/record_type/vmad.rs
@@ -37,8 +37,6 @@ use nom::{
     error::Error,
     number::complete::{le_f32, le_i8, le_i16, le_i32, le_u8, le_u16, le_u32},
 };
-use rusqlite::hooks::TransactionOperation::Unknown;
-
 /// VMAD Script Property Value Types
 #[derive(Debug, Clone, PartialEq)]
 pub enum ScriptPropertyValue {

--- a/crates/launcher/Cargo.toml
+++ b/crates/launcher/Cargo.toml
@@ -7,3 +7,6 @@ edition.workspace = true
 converter = { path = "../converter/" }
 bevy.workspace = true
 crossbeam-channel = "0.5.16"
+
+[target.'cfg(windows)'.dependencies]
+winreg = "0.55"

--- a/crates/launcher/src/game_detection.rs
+++ b/crates/launcher/src/game_detection.rs
@@ -1,0 +1,173 @@
+use std::collections::HashSet;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+const SKYRIM_STEAM_APP_ID: &str = "489830";
+const SKYRIM_DEFAULT_INSTALL_DIR: &str = "Skyrim Special Edition";
+
+pub fn find_skyrim_data_dir() -> Option<PathBuf> {
+    local_candidates()
+        .into_iter()
+        .chain(steam_library_paths())
+        .find_map(find_skyrim_in_root)
+}
+
+fn local_candidates() -> [PathBuf; 2] {
+    [PathBuf::from("skyrim_game"), PathBuf::from("game_data")]
+}
+
+fn find_skyrim_in_root(root: PathBuf) -> Option<PathBuf> {
+    let direct_data = root.join("Data");
+    if is_skyrim_data_dir(&direct_data) {
+        return Some(direct_data);
+    }
+
+    let steamapps = root.join("steamapps");
+    let manifest = steamapps.join(format!("appmanifest_{SKYRIM_STEAM_APP_ID}.acf"));
+    let install_dir = fs::read_to_string(manifest)
+        .ok()
+        .and_then(|contents| vdf_value(&contents, "installdir"))
+        .unwrap_or_else(|| SKYRIM_DEFAULT_INSTALL_DIR.to_owned());
+    let data_dir = steamapps.join("common").join(install_dir).join("Data");
+
+    is_skyrim_data_dir(&data_dir).then_some(data_dir)
+}
+
+fn is_skyrim_data_dir(data_dir: &Path) -> bool {
+    data_dir.join("Skyrim.esm").is_file()
+}
+
+fn steam_library_paths() -> Vec<PathBuf> {
+    let mut paths = Vec::new();
+
+    for steam_root in steam_install_paths() {
+        paths.push(steam_root.clone());
+
+        let library_file = steam_root.join("steamapps").join("libraryfolders.vdf");
+        if let Ok(contents) = fs::read_to_string(library_file) {
+            paths.extend(vdf_values(&contents, "path").into_iter().map(PathBuf::from));
+        }
+    }
+
+    let mut seen = HashSet::new();
+    paths
+        .into_iter()
+        .filter(|path| seen.insert(path.clone()))
+        .collect()
+}
+
+#[cfg(windows)]
+fn steam_install_paths() -> Vec<PathBuf> {
+    use winreg::RegKey;
+    use winreg::enums::{HKEY_CURRENT_USER, HKEY_LOCAL_MACHINE};
+
+    let candidates = [
+        (HKEY_CURRENT_USER, r"Software\Valve\Steam", "SteamPath"),
+        (HKEY_LOCAL_MACHINE, r"SOFTWARE\Valve\Steam", "InstallPath"),
+        (
+            HKEY_LOCAL_MACHINE,
+            r"SOFTWARE\WOW6432Node\Valve\Steam",
+            "InstallPath",
+        ),
+    ];
+
+    candidates
+        .into_iter()
+        .filter_map(|(hive, key_path, value_name)| {
+            RegKey::predef(hive)
+                .open_subkey(key_path)
+                .ok()?
+                .get_value::<String, _>(value_name)
+                .ok()
+        })
+        .map(PathBuf::from)
+        .collect()
+}
+
+#[cfg(not(windows))]
+fn steam_install_paths() -> Vec<PathBuf> {
+    Vec::new()
+}
+
+fn vdf_value(contents: &str, key: &str) -> Option<String> {
+    vdf_values(contents, key).into_iter().next()
+}
+
+fn vdf_values(contents: &str, key: &str) -> Vec<String> {
+    let tokens = quoted_vdf_tokens(contents);
+    tokens
+        .windows(2)
+        .filter(|pair| pair[0].eq_ignore_ascii_case(key))
+        .map(|pair| pair[1].clone())
+        .collect()
+}
+
+fn quoted_vdf_tokens(contents: &str) -> Vec<String> {
+    let mut tokens = Vec::new();
+    let mut chars = contents.chars().peekable();
+
+    while let Some(ch) = chars.next() {
+        if ch != '"' {
+            continue;
+        }
+
+        let mut token = String::new();
+        while let Some(ch) = chars.next() {
+            match ch {
+                '"' => break,
+                '\\' => match chars.peek().copied() {
+                    Some('"') | Some('\\') => token.push(chars.next().unwrap()),
+                    _ => token.push('\\'),
+                },
+                _ => token.push(ch),
+            }
+        }
+        tokens.push(token);
+    }
+
+    tokens
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    #[test]
+    fn reads_all_library_paths_from_modern_steam_vdf() {
+        let contents = r#"
+            "libraryfolders"
+            {
+                "0" { "path" "C:\\Program Files (x86)\\Steam" }
+                "1" { "path" "D:\\SteamLibrary" }
+            }
+        "#;
+
+        assert_eq!(
+            vdf_values(contents, "path"),
+            [r"C:\Program Files (x86)\Steam", r"D:\SteamLibrary"]
+        );
+    }
+
+    #[test]
+    fn uses_manifest_install_directory() {
+        let unique = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let root = std::env::temp_dir().join(format!("openskyrim-steam-detection-{unique}"));
+        let steamapps = root.join("steamapps");
+        let data_dir = steamapps.join("common").join("Skyrim SSE").join("Data");
+        fs::create_dir_all(&data_dir).unwrap();
+        fs::write(data_dir.join("Skyrim.esm"), []).unwrap();
+        fs::write(
+            steamapps.join("appmanifest_489830.acf"),
+            r#""AppState" { "appid" "489830" "installdir" "Skyrim SSE" }"#,
+        )
+        .unwrap();
+
+        assert_eq!(find_skyrim_in_root(root.clone()), Some(data_dir));
+
+        fs::remove_dir_all(root).unwrap();
+    }
+}

--- a/crates/launcher/src/handlers.rs
+++ b/crates/launcher/src/handlers.rs
@@ -1,4 +1,7 @@
-use crate::components::{PlayButton, ProgressBarFill, StatusText};
+use crate::{
+    components::{PlayButton, ProgressBarFill, StatusText},
+    game_detection::find_skyrim_data_dir,
+};
 
 use super::{
     ConversionChannel, ConversionProgressEvent, ConversionStatus, GamePathConfig, LauncherState,
@@ -13,17 +16,23 @@ pub fn detect_skyrim_and_start_conversion(
     mut config: ResMut<GamePathConfig>,
     mut status: ResMut<ConversionStatus>,
 ) {
-    let local_skyrim = std::path::Path::new("./skyrim_game/Data/Skyrim.esm");
     let db_exists = std::path::Path::new("./modern_assets/skyrim_world.db").exists();
 
-    if local_skyrim.exists() {
-        config.skyrim_data_path = Some("skyrim_game/Data".into());
+    if let Some(data_dir) = find_skyrim_data_dir() {
+        config.skyrim_data_path = Some(data_dir.clone());
 
         if db_exists {
             status.progress = 1.0;
-            status.current_step = "Assets converted! Ready to play.".into();
+            status.current_step = format!(
+                "Skyrim found at {}. Assets converted! Ready to play.",
+                data_dir.display()
+            );
             status.is_complete = true;
         } else {
+            status.current_step = format!(
+                "Skyrim found at {}. Starting conversion...",
+                data_dir.display()
+            );
             let (tx, rx) = unbounded::<ConversionProgressEvent>();
             commands.insert_resource(ConversionChannel { receiver: rx });
 
@@ -33,7 +42,8 @@ pub fn detect_skyrim_and_start_conversion(
         }
         next_state.set(LauncherState::ModManager);
     } else {
-        status.current_step = "Skyrim game files not found. Drag & drop Skyrim folder here.".into();
+        status.current_step =
+            "Skyrim Special Edition was not found in Steam libraries or local folders.".into();
         next_state.set(LauncherState::FirstRunSetup);
     }
 }
@@ -81,6 +91,19 @@ pub fn update_conversion_progress(
                 text.0 = format!("{} ({:.0}%)", event.current_file, event.percentage * 100.0);
             }
         }
+    }
+}
+
+pub fn sync_status_text(
+    status: Res<ConversionStatus>,
+    mut text_query: Query<&mut Text, With<StatusText>>,
+) {
+    if !status.is_changed() {
+        return;
+    }
+
+    for mut text in text_query.iter_mut() {
+        text.0 = status.current_step.clone();
     }
 }
 

--- a/crates/launcher/src/main.rs
+++ b/crates/launcher/src/main.rs
@@ -1,4 +1,5 @@
 mod components;
+mod game_detection;
 mod handlers;
 mod ui;
 
@@ -76,6 +77,7 @@ fn main() {
             Update,
             (
                 update_conversion_progress,
+                sync_status_text.after(update_conversion_progress),
                 handle_play_button_click,
                 handle_mod_drag_and_drop,
             ),


### PR DESCRIPTION
## What changed

- locate the Steam installation through the Windows registry
- parse `libraryfolders.vdf` to search every configured Steam library
- read Skyrim Special Edition's app manifest (`489830`) to honor custom install directory names
- validate the installation using `Data/Skyrim.esm`
- retain the existing local `skyrim_game` and `game_data` fallbacks
- synchronize the detection result with the launcher status text
- add tests for multi-library VDF parsing and custom manifest install directories
- remove unused converter imports and an unused `cell_form_id` assignment

## Why

The launcher only checked `./skyrim_game/Data/Skyrim.esm`. Normal Steam installations were therefore reported as an endless “Locating Skyrim game files...” state, while clicking Play printed conversion progress at 0%.

The converter cleanup removes four compiler warnings caused by dead code without changing conversion behavior.

## Impact

Windows users with Skyrim Special Edition installed through Steam can launch OpenSkyrim without copying game files into the repository. Installations in secondary Steam libraries are supported, and launcher builds no longer emit the reported converter warnings.

## Validation

- `cargo check -p launcher` — passed without warnings
- `cargo test -p launcher` — 2 passed
- `git diff --check` — passed
