### PR TITLE
fix(converter): harden BSA archive parsing

### DIFF
--- a/crates/converter/src/archive/bsa.rs
+++ b/crates/converter/src/archive/bsa.rs
@@ -1,12 +1,16 @@
 use color_eyre::{
     Result,
-    eyre::{WrapErr, bail, ensure},
+    eyre::{WrapErr, bail, ensure, eyre},
 };
 use flate2::read::ZlibDecoder;
 use std::io::Read;
 
+const HEADER_SIZE: usize = 36;
+const FILE_RECORD_SIZE: usize = 16;
 const ARCHIVE_COMPRESSED: u32 = 0x0004;
 const ARCHIVE_EMBED_FILE_NAMES: u32 = 0x0100;
+const KNOWN_ARCHIVE_FLAGS: u32 = 0x03ff;
+const KNOWN_FILE_FLAGS: u32 = 0x01ff;
 const FILE_COMPRESSION_TOGGLE: u32 = 0x4000_0000;
 const FILE_SIZE_MASK: u32 = 0x3fff_ffff;
 
@@ -17,6 +21,7 @@ struct FileRecord {
     offset: u32,
 }
 
+#[derive(Debug)]
 pub struct BsaRawEntry<'a> {
     pub name: String,
     pub payload: &'a [u8],
@@ -37,80 +42,124 @@ impl<'a> BsaRawEntry<'a> {
 // Reads BSA metadata table only
 // Payloads remain lightweight slices into the mmap
 pub(crate) fn iter_raw_entries<'a>(bytes: &'a [u8]) -> Result<Vec<BsaRawEntry<'a>>> {
-    ensure!(bytes.len() >= 36, "truncated BSA header");
+    ensure!(bytes.len() >= HEADER_SIZE, "truncated BSA header");
     ensure!(&bytes[..4] == b"BSA\0", "invalid BSA magic");
     let version = u32_at(bytes, 4)?;
     ensure!(
         matches!(version, 104 | 105),
         "unsupported BSA version {version}"
     );
+    let folder_record_offset = u32_at(bytes, 8)? as usize;
+    ensure!(
+        folder_record_offset == HEADER_SIZE,
+        "unsupported BSA folder record offset {folder_record_offset}"
+    );
     let archive_flags = u32_at(bytes, 12)?;
+    ensure!(
+        archive_flags & !KNOWN_ARCHIVE_FLAGS == 0,
+        "unsupported BSA archive flags: {archive_flags:#010x}"
+    );
     let folder_count = u32_at(bytes, 16)? as usize;
     let file_count = u32_at(bytes, 20)? as usize;
-    let folder_record_size = if version >= 105 { 24 } else { 16 };
-    let folder_table_end = 36usize
-        .checked_add(
-            folder_count
-                .checked_mul(folder_record_size)
-                .ok_or_else(|| color_eyre::eyre::eyre!("BSA folder count overflow"))?,
-        )
-        .ok_or_else(|| color_eyre::eyre::eyre!("BSA folder table overflow"))?;
+    let total_folder_name_length = u32_at(bytes, 24)? as usize;
+    let total_file_name_length = u32_at(bytes, 28)? as usize;
+    let file_flags = u32_at(bytes, 32)?;
     ensure!(
-        folder_table_end <= bytes.len(),
-        "truncated BSA folder table"
+        file_flags & !KNOWN_FILE_FLAGS == 0,
+        "unsupported BSA file flags: {file_flags:#010x}"
+    );
+    let folder_record_size = if version >= 105 { 24 } else { 16 };
+    let folder_table_size = folder_count
+        .checked_mul(folder_record_size)
+        .ok_or_else(|| eyre!("BSA folder count overflow"))?;
+    let folder_table_end = checked_end(folder_record_offset, folder_table_size, "folder table")?;
+
+    // Validate all count-derived metadata before allocating. Besides detecting corrupt
+    // headers early, this prevents attacker-controlled capacities from aborting the process.
+    let file_records_size = file_count
+        .checked_mul(FILE_RECORD_SIZE)
+        .ok_or_else(|| eyre!("BSA file count overflow"))?;
+    let minimum_metadata_end = checked_end(folder_table_end, folder_count, "folder names")
+        .and_then(|end| checked_end(end, total_folder_name_length, "folder names"))
+        .and_then(|end| checked_end(end, file_records_size, "file records"))
+        .and_then(|end| checked_end(end, total_file_name_length, "filename table"))?;
+    ensure!(
+        minimum_metadata_end <= bytes.len(),
+        "BSA metadata exceeds archive size"
     );
 
     let mut folder_file_counts = Vec::with_capacity(folder_count);
     for index in 0..folder_count {
-        let base = 36 + index * folder_record_size;
+        let base = folder_record_offset + index * folder_record_size;
         folder_file_counts.push(u32_at(bytes, base + 8)? as usize);
     }
 
     let mut cursor = folder_table_end;
     let mut records = Vec::with_capacity(file_count);
+    let mut folder_names_length = 0usize;
     for count in folder_file_counts {
-        let name_len = *bytes
-            .get(cursor)
-            .ok_or_else(|| color_eyre::eyre::eyre!("missing BSA folder name"))?
-            as usize;
-        cursor += 1;
+        let name_len = slice_at(bytes, cursor, 1, "folder name length")?[0] as usize;
+        cursor = checked_end(cursor, 1, "folder name length")?;
+        let folder_bytes = slice_at(bytes, cursor, name_len, "folder name")?;
         ensure!(
-            cursor + name_len <= bytes.len(),
-            "truncated BSA folder name"
+            folder_bytes.is_empty() || folder_bytes.last() == Some(&0),
+            "BSA folder name is not null-terminated"
         );
-        let folder_bytes = &bytes[cursor..cursor + name_len];
         let folder = String::from_utf8_lossy(folder_bytes)
             .trim_end_matches('\0')
             .to_string();
-        cursor += name_len;
+        cursor = checked_end(cursor, name_len, "folder name")?;
+        folder_names_length = folder_names_length
+            .checked_add(name_len)
+            .ok_or_else(|| eyre!("BSA folder name length overflow"))?;
+        ensure!(
+            records
+                .len()
+                .checked_add(count)
+                .is_some_and(|sum| sum <= file_count),
+            "BSA folder records exceed declared file count"
+        );
         for _ in 0..count {
-            ensure!(cursor + 16 <= bytes.len(), "truncated BSA file record");
+            slice_at(bytes, cursor, FILE_RECORD_SIZE, "file record")?;
             records.push(FileRecord {
                 folder: folder.clone(),
                 size_flags: u32_at(bytes, cursor + 8)?,
                 offset: u32_at(bytes, cursor + 12)?,
             });
-            cursor += 16;
+            cursor = checked_end(cursor, FILE_RECORD_SIZE, "file record")?;
         }
     }
+    ensure!(
+        folder_names_length == total_folder_name_length,
+        "BSA folder name length mismatch: header={total_folder_name_length}, records={folder_names_length}"
+    );
     ensure!(
         records.len() == file_count,
         "BSA file count mismatch: header={file_count}, records={}",
         records.len()
     );
 
+    let filename_table_end = checked_end(cursor, total_file_name_length, "filename table")?;
+    let filename_table = slice_at(bytes, cursor, total_file_name_length, "filename table")?;
     let mut names = Vec::with_capacity(file_count);
+    let mut name_cursor = 0usize;
     for _ in 0..file_count {
-        let tail = bytes
-            .get(cursor..)
-            .ok_or_else(|| color_eyre::eyre::eyre!("missing BSA filename table"))?;
+        let tail = filename_table
+            .get(name_cursor..)
+            .ok_or_else(|| eyre!("missing BSA filename table"))?;
         let end = tail
             .iter()
             .position(|byte| *byte == 0)
-            .ok_or_else(|| color_eyre::eyre::eyre!("unterminated BSA filename"))?;
+            .ok_or_else(|| eyre!("unterminated BSA filename"))?;
+        ensure!(end > 0, "BSA filename is empty");
         names.push(String::from_utf8_lossy(&tail[..end]).to_string());
-        cursor += end + 1;
+        name_cursor = checked_end(name_cursor, end + 1, "filename")?;
     }
+    ensure!(
+        name_cursor == filename_table.len(),
+        "BSA filename table length mismatch: header={}, records={name_cursor}",
+        filename_table.len()
+    );
 
     records
         .into_iter()
@@ -123,22 +172,21 @@ pub(crate) fn iter_raw_entries<'a>(bytes: &'a [u8]) -> Result<Vec<BsaRawEntry<'a
             };
             let stored_size = (record.size_flags & FILE_SIZE_MASK) as usize;
             let start = record.offset as usize;
-            let end = start
-                .checked_add(stored_size)
-                .ok_or_else(|| color_eyre::eyre::eyre!("BSA file range overflow"))?;
-            let mut payload = bytes.get(start..end).ok_or_else(|| {
-                color_eyre::eyre::eyre!("BSA file payload out of bounds: {full_name}")
-            })?;
+            ensure!(
+                start >= filename_table_end,
+                "BSA file payload overlaps metadata: {full_name}"
+            );
+            let mut payload = slice_at(bytes, start, stored_size, "file payload")
+                .wrap_err_with(|| format!("invalid BSA file payload: {full_name}"))?;
             if archive_flags & ARCHIVE_EMBED_FILE_NAMES != 0 {
                 let embedded_len = *payload
                     .first()
-                    .ok_or_else(|| color_eyre::eyre::eyre!("missing embedded BSA filename"))?
+                    .ok_or_else(|| eyre!("missing embedded BSA filename"))?
                     as usize;
-                ensure!(
-                    payload.len() > embedded_len,
-                    "truncated embedded BSA filename"
-                );
-                payload = &payload[embedded_len + 1..];
+                let payload_start = checked_end(1, embedded_len, "embedded filename")?;
+                payload = payload
+                    .get(payload_start..)
+                    .ok_or_else(|| eyre!("truncated embedded BSA filename"))?;
             }
 
             let is_compressed = (archive_flags & ARCHIVE_COMPRESSED != 0)
@@ -189,12 +237,23 @@ fn decompress(payload: &[u8], version: u32) -> Result<Vec<u8>> {
 }
 
 fn u32_at(bytes: &[u8], offset: usize) -> Result<u32> {
-    let raw: [u8; 4] = bytes
-        .get(offset..offset + 4)
-        .ok_or_else(|| color_eyre::eyre::eyre!("truncated u32 at offset {offset}"))?
+    let raw: [u8; 4] = slice_at(bytes, offset, 4, "u32")?
         .try_into()
-        .unwrap();
+        .map_err(|_| eyre!("invalid u32 at offset {offset}"))?;
     Ok(u32::from_le_bytes(raw))
+}
+
+fn checked_end(start: usize, length: usize, field: &str) -> Result<usize> {
+    start
+        .checked_add(length)
+        .ok_or_else(|| eyre!("BSA {field} range overflow"))
+}
+
+fn slice_at<'a>(bytes: &'a [u8], start: usize, length: usize, field: &str) -> Result<&'a [u8]> {
+    let end = checked_end(start, length, field)?;
+    bytes
+        .get(start..end)
+        .ok_or_else(|| eyre!("truncated BSA {field} at offset {start}"))
 }
 
 #[cfg(test)]
@@ -202,18 +261,17 @@ mod tests {
     use super::*;
     use std::io::Write;
 
-    #[test]
-    fn extracts_uncompressed_skyrim_bsa_fixture() {
+    fn uncompressed_fixture() -> Vec<u8> {
         let folder = b"scripts\0";
         let name = b"hello.pex\0";
         let payload = b"PEX";
-        let folder_table_end = 36 + 16;
-        let names_start = folder_table_end + 1 + folder.len() + 16;
+        let folder_table_end = HEADER_SIZE + FILE_RECORD_SIZE;
+        let names_start = folder_table_end + 1 + folder.len() + FILE_RECORD_SIZE;
         let payload_offset = names_start + name.len();
         let mut bytes = vec![0u8; payload_offset];
         bytes[..4].copy_from_slice(b"BSA\0");
         bytes[4..8].copy_from_slice(&104u32.to_le_bytes());
-        bytes[8..12].copy_from_slice(&36u32.to_le_bytes());
+        bytes[8..12].copy_from_slice(&(HEADER_SIZE as u32).to_le_bytes());
         bytes[16..20].copy_from_slice(&1u32.to_le_bytes());
         bytes[20..24].copy_from_slice(&1u32.to_le_bytes());
         bytes[24..28].copy_from_slice(&(folder.len() as u32).to_le_bytes());
@@ -229,12 +287,107 @@ mod tests {
         cursor += 16;
         bytes[cursor..cursor + name.len()].copy_from_slice(name);
         bytes.extend_from_slice(payload);
+        bytes
+    }
 
+    #[test]
+    fn extracts_uncompressed_skyrim_bsa_fixture() {
+        let bytes = uncompressed_fixture();
         let entries = iter_raw_entries(&bytes).unwrap();
         assert_eq!(entries.len(), 1);
         assert_eq!(entries[0].name, "scripts/hello.pex");
-        assert_eq!(entries[0].payload, payload);
-        assert_eq!(entries[0].decompress().unwrap(), payload);
+        assert_eq!(entries[0].payload, b"PEX");
+        assert_eq!(entries[0].decompress().unwrap(), b"PEX");
+    }
+
+    #[test]
+    fn every_truncated_fixture_returns_an_error_without_panicking() {
+        let bytes = uncompressed_fixture();
+        for length in 0..bytes.len() {
+            let result = std::panic::catch_unwind(|| iter_raw_entries(&bytes[..length]));
+            assert!(result.is_ok(), "parser panicked for length {length}");
+            assert!(
+                result.unwrap().is_err(),
+                "truncated fixture was accepted at length {length}"
+            );
+        }
+    }
+
+    #[test]
+    fn rejects_unsupported_versions_offsets_and_flags() {
+        for (range, value, expected) in [
+            (4..8, 103u32, "unsupported BSA version"),
+            (8..12, 40u32, "unsupported BSA folder record offset"),
+            (12..16, 0x8000_0000u32, "unsupported BSA archive flags"),
+            (32..36, 0x8000_0000u32, "unsupported BSA file flags"),
+        ] {
+            let mut bytes = uncompressed_fixture();
+            bytes[range].copy_from_slice(&value.to_le_bytes());
+            let error = iter_raw_entries(&bytes).unwrap_err().to_string();
+            assert!(error.contains(expected), "unexpected error: {error}");
+        }
+    }
+
+    #[test]
+    fn rejects_count_and_name_length_mismatches() {
+        let mut excessive_folder_count = uncompressed_fixture();
+        excessive_folder_count[44..48].copy_from_slice(&2u32.to_le_bytes());
+        assert!(
+            iter_raw_entries(&excessive_folder_count)
+                .unwrap_err()
+                .to_string()
+                .contains("folder records exceed declared file count")
+        );
+
+        let mut wrong_folder_name_length = uncompressed_fixture();
+        wrong_folder_name_length[24..28].copy_from_slice(&7u32.to_le_bytes());
+        assert!(iter_raw_entries(&wrong_folder_name_length).is_err());
+
+        let mut unterminated_filename = uncompressed_fixture();
+        let filename_terminator = unterminated_filename.len() - b"PEX".len() - 1;
+        unterminated_filename[filename_terminator] = b'x';
+        assert!(
+            iter_raw_entries(&unterminated_filename)
+                .unwrap_err()
+                .to_string()
+                .contains("unterminated BSA filename")
+        );
+    }
+
+    #[test]
+    fn rejects_huge_counts_and_overlapping_payloads_without_panicking() {
+        let mut huge_count = uncompressed_fixture();
+        huge_count[20..24].copy_from_slice(&u32::MAX.to_le_bytes());
+        let result = std::panic::catch_unwind(|| iter_raw_entries(&huge_count));
+        assert!(result.is_ok());
+        assert!(result.unwrap().is_err());
+
+        let mut overlapping_payload = uncompressed_fixture();
+        overlapping_payload[73..77].copy_from_slice(&(HEADER_SIZE as u32).to_le_bytes());
+        assert!(
+            iter_raw_entries(&overlapping_payload)
+                .unwrap_err()
+                .to_string()
+                .contains("payload overlaps metadata")
+        );
+
+        assert!(u32_at(&[], usize::MAX).is_err());
+    }
+
+    #[test]
+    fn rejects_truncated_and_size_mismatched_compressed_payloads() {
+        assert!(decompress(&[0, 0, 0], 104).is_err());
+
+        let mut payload = 10u32.to_le_bytes().to_vec();
+        let mut encoder = flate2::write::ZlibEncoder::new(Vec::new(), flate2::Compression::fast());
+        encoder.write_all(b"short").unwrap();
+        payload.extend_from_slice(&encoder.finish().unwrap());
+        assert!(
+            decompress(&payload, 104)
+                .unwrap_err()
+                .to_string()
+                .contains("decompressed size mismatch")
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Objective

Harden the BSA reader against corrupted headers, unsupported variants, invalid metadata, and out-of-bounds payloads. Fixes #8.

## Details & Implementation

- validates versions, folder-record offsets, archive/file flags, counts, declared name lengths, and payload boundaries before extraction
- uses checked range helpers and `color-eyre` propagation instead of the remaining parser `unwrap`
- rejects metadata-overlapping payloads, unterminated names, truncated embedded names, and malformed compressed data with contextual errors
- adds procedurally generated tests for truncation at every fixture boundary, oversized counts, invalid flags/variants, count and length mismatches, payload overlap, and decompression failures

## Verification & Testing

- **Environment**: OS: `Windows` | Backend: `N/A`
- **Commands executed**:
  - [x] `cargo check --workspace`
  - [ ] `cargo test --workspace` (63/66 CI tests passed. Three unrelated failures already exist on the base branch because `emit_luau_to` emits quoted Luau strings split by literal newlines; this reproduces on Windows and Linux.)
  - [x] `cargo test -p converter archive::bsa --no-fail-fast` (7 passed locally and in CI)
  - [x] `cargo fmt --all -- --check` (passed locally and in CI)
  - [ ] `cargo clippy --workspace --all-targets --all-features -- -D warnings` (passed locally with Rust 1.97.1; CI Rust 1.98 reports four unrelated pre-existing `chunks_exact_to_as_chunks` lints in ESM files unchanged by this PR)
  - [ ] Manual runtime testing (no proprietary BSA assets used)

### Visual / Benchmark Proof (Optional)

Not applicable; parser-only change with procedurally generated fixtures.