### PR TITLE
fix(ci): restore passing converter tests

### DIFF
--- a/crates/converter/src/esm/cell_cache.rs
+++ b/crates/converter/src/esm/cell_cache.rs
@@ -116,7 +116,7 @@ fn extract_texture_layers(subrecords: &[(Vec<u8>, Vec<u8>)]) -> Vec<TerrainLayer
             }
             b"VTXT" => {
                 if let Some(index) = active {
-                    for entry in data.chunks_exact(8) {
+                    for entry in data.as_chunks::<8>().0 {
                         layers[index].weights.push(TerrainWeight {
                             vertex: u16::from_le_bytes(entry[..2].try_into().unwrap()),
                             opacity: f32::from_le_bytes(entry[4..8].try_into().unwrap()),

--- a/crates/converter/src/esm/extractors.rs
+++ b/crates/converter/src/esm/extractors.rs
@@ -134,7 +134,9 @@ impl<'a> SubrecordView<'a> {
     /// Read a float vector / transform (e.g. DATA in REFR: 3 pos + 3 rot = 24 bytes)
     pub fn get_f32_slice(&self, target_tag: &[u8; 4]) -> Option<Vec<f32>> {
         self.find(target_tag).map(|d| {
-            d.chunks_exact(4)
+            d.as_chunks::<4>()
+                .0
+                .iter()
                 .map(|b| f32::from_le_bytes([b[0], b[1], b[2], b[3]]))
                 .collect()
         })

--- a/crates/converter/src/esm/records/tes4.rs
+++ b/crates/converter/src/esm/records/tes4.rs
@@ -125,7 +125,7 @@ impl EsmRecord for Tes4Record {
 
         let mut overrides = Vec::new();
         if let Some(onam_raw) = view.find(b"ONAM") {
-            for chunk in onam_raw.chunks_exact(4) {
+            for chunk in onam_raw.as_chunks::<4>().0 {
                 overrides.push(u32::from_le_bytes([chunk[0], chunk[1], chunk[2], chunk[3]]));
             }
         }

--- a/crates/converter/src/esm/records/tree.rs
+++ b/crates/converter/src/esm/records/tree.rs
@@ -55,7 +55,7 @@ impl EsmRecord for TreeRecord {
         let name = view.get_string(b"FULL");
         let data = view.find(b"CNAM").filter(|d| d.len() >= 48).map(|d| {
             let mut floats = [0.0f32; 12];
-            for (i, chunk) in d.chunks_exact(4).take(12).enumerate() {
+            for (i, chunk) in d.as_chunks::<4>().0.iter().take(12).enumerate() {
                 floats[i] = f32::from_le_bytes([chunk[0], chunk[1], chunk[2], chunk[3]]);
             }
 

--- a/crates/converter/src/script.rs
+++ b/crates/converter/src/script.rs
@@ -270,15 +270,10 @@ impl ScriptConverter {
         }
         writeln!(out, "}}")?;
         writeln!(out, "function Script.new(runtime)")?;
+        writeln!(out, "    assert(runtime, \"Papyrus runtime is required\")")?;
         writeln!(
             out,
-            "    assert(runtime, \"Papyrus runtime is
-          required\")"
-        )?;
-        writeln!(
-            out,
-            "    local self = setmetatable({{ __runtime = runtime }},
-          Script)"
+            "    local self = setmetatable({{ __runtime = runtime }}, Script)"
         )?;
         for variable in &object.variables {
             writeln!(
@@ -308,8 +303,7 @@ impl ScriptConverter {
                 if property.writable {
                     writeln!(
                         out,
-                        "Script[{}] = function(self, value) self[{}] = value
-              end",
+                        "Script[{}] = function(self, value) self[{}] = value end",
                         lua_string(&format!("set_{}", property.name)),
                         lua_string(auto_var)
                     )?;
@@ -340,7 +334,7 @@ impl ScriptConverter {
                 )?;
             }
         }
-        writeln!(out, "return script")?;
+        writeln!(out, "return Script")?;
         Ok(())
     }
 }


### PR DESCRIPTION
## Objective

Restore the failing tests and required CI checks on main.

## Details & Implementation

- Repair malformed multiline Luau emitted by ScriptConverter.
- Return the correctly cased Script table from generated artifacts.
- Replace four chunks_exact calls with equivalent as_chunks iteration required by Clippy 1.98.

## Verification & Testing

- Environment: Windows; Rust 1.98.0
- cargo test --workspace: passed (60 passed, 1 ignored manual fixture)
- cargo fmt --all -- --check: passed
- cargo clippy --workspace --all-targets --all-features -- -D warnings: passed
